### PR TITLE
KRAK-4838: adds iframe sync option to prebid server

### DIFF
--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -10,6 +10,9 @@ capabilities:
       - video
       - native
 userSync:
+  iframe:
+    url: "https://crb.kargo.com/api/v1/initsyncpbs?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"
+    userMacro: "$UID"
   redirect:
     url: "https://crb.kargo.com/api/v1/dsync/PrebidServer?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"
     userMacro: "$UID"


### PR DESCRIPTION
Required to finish implementation of adding iframe sync support to prebid server. 
Related to - https://github.com/KargoGlobal/cerberus/pull/160