### PR TITLE
Enabled app based requests via prebid bidder info

### DIFF
--- a/static/bidder-info/kargo.yaml
+++ b/static/bidder-info/kargo.yaml
@@ -9,6 +9,11 @@ capabilities:
       - banner
       - video
       - native
+  app:
+    mediaTypes:
+      - banner
+      - video
+      - native
 userSync:
   redirect:
     url: "https://crb.kargo.com/api/v1/dsync/PrebidServer?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&r={{.RedirectURL}}"


### PR DESCRIPTION
Still have some testing to do but this should be the configuration change we're looking for. Could use some guidance re:who to review this internally before I open the upstream public PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kargo bidder now declares expanded OpenRTB capabilities, adding support for banner, video, and native media types in app environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->